### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Mongoext
 ========
 
-.. image:: https://pypip.in/wheel/mongoext/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/mongoext.svg
    :target: https://pypi.python.org/pypi/mongoext/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mongoext))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mongoext`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.